### PR TITLE
Only publish from the 18.x matrix entry

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
       - run: npm info
-      - if: startsWith(github.ref, 'refs/tags')
+      - if: matrix.node == '18.x' && startsWith(github.ref, 'refs/tags')
         run: npm publish
       - if: startsWith(github.ref, 'refs/heads')
         run: npm publish --dry-run


### PR DESCRIPTION
because attempting to publish the same version more than once results in a very sad npm.