### PR TITLE
recent connect, updated config, passes tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,8 @@ jobs:
           - 16.x
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - run: npm install

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ distclean: clean
 .PHONY: up
 up: .require-license
 	docker-compose port connect 3939 2>/dev/null | if ! grep -q ':23939$$'; then \
-		docker-compose up -d; \
+		docker-compose up -d --wait; \
 	fi
 
 .PHONY: down

--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,13 @@ distclean: clean
 
 .PHONY: up
 up: .require-license
-	docker-compose port connect 3939 2>/dev/null | if ! grep -q ':23939$$'; then \
-		docker-compose up -d --wait; \
+	docker compose port connect 3939 2>/dev/null | if ! grep -q ':23939$$'; then \
+		docker compose up -d --wait; \
 	fi
 
 .PHONY: down
 down:
-	docker-compose down --remove-orphans
+	docker compose down --remove-orphans
 
 .PHONY: .require-license
 .require-license:

--- a/__tests__/main.spec.ts
+++ b/__tests__/main.spec.ts
@@ -8,7 +8,7 @@ import * as rsconnect from '../src/main'
 jest.setTimeout(1000 * 60 * 2)
 
 const SEED_ADMIN_CONFIG: rsconnect.APIClientConfiguration = {
-  apiKey: 'f1wc3w4090uv67yhud7j08zjzgvt7yfg',
+  apiKey: '21232f297a57a5a743894a0e4a801fc3',
   baseURL: 'http://127.0.0.1:23939/__api__'
 }
 

--- a/__tests__/rstudio-connect.test.gcfg
+++ b/__tests__/rstudio-connect.test.gcfg
@@ -4,7 +4,7 @@
 DataDir = /data
 EmailProvider = print
 DatabaseEmailSettings = true
-Address = http://localhost:23939
+Address = http://127.0.0.1:23939
 
 [Authentication]
 Provider = password

--- a/__tests__/rstudio-connect.test.gcfg
+++ b/__tests__/rstudio-connect.test.gcfg
@@ -13,15 +13,11 @@ InsecureDefaultUserAPIKey = true
 APIKeyBcryptCost = 4
 
 [Database]
-Provider = Postgres
 SeedUsers = true
 
 [HTTP]
 Listen = :3939
 NoWarning = true
-
-[Postgres]
-URL = postgres://postgres:notasecret@db/postgres?sslmode=disable
 
 [Python]
 Enabled = true

--- a/__tests__/rstudio-connect.test.gcfg
+++ b/__tests__/rstudio-connect.test.gcfg
@@ -1,42 +1,46 @@
 ; RStudio Connect test environment configuration
 
-[Applications]
-RunAs = rstudio-connect
+[Server]
+DataDir = /data
+EmailProvider = print
+DatabaseEmailSettings = true
+Address = http://localhost:23939
 
 [Authentication]
 Provider = password
+BasicAuth = true
+InsecureDefaultUserAPIKey = true
+APIKeyBcryptCost = 4
 
 [Database]
 Provider = Postgres
 SeedUsers = true
 
-[Debug]
-Log = router
-Log = services
-Log = url-normalization
-
 [HTTP]
 Listen = :3939
 NoWarning = true
-
-[Mount]
-BaseDir = /connect-test-mount
 
 [Postgres]
 URL = postgres://postgres:notasecret@db/postgres?sslmode=disable
 
 [Python]
 Enabled = true
-Executable = /opt/python/3.6.5/bin/python
+Executable = /opt/python/3.12.1/bin/python
+Executable = /opt/python/3.11.7/bin/python
+
+[Quarto]
+Enabled = true
+Executable = /opt/quarto/1.4.552/bin/quarto
 
 [RPackageRepository "CRAN"]
-URL = https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+URL = https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
 
 [RPackageRepository "RSPM"]
-URL = https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+URL = https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
 
-[Server]
-DataDir = /data
-EmailProvider = print
-DatabaseEmailSettings = true
-Address = http://127.0.0.1:23939
+[Logging]
+ServiceLog = STDOUT
+ServiceLogFormat = TEXT    ; TEXT or JSON
+ServiceLogLevel = INFO     ; INFO, WARNING or ERROR
+AccessLog = STDOUT
+AccessLogFormat = COMMON   ; COMMON, COMBINED, or JSON

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   db:
     image: postgres:12
@@ -11,9 +9,7 @@ services:
     privileged: true
     depends_on:
       - db
-    # TODO: when available
-    # image: rstudio/rstudio-connect:1.8.6
-    image: rstudio/rstudio-connect:1.8.4.2-2
+    image: rstudio/rstudio-connect:ubuntu2204-2024.05.0
     volumes:
       - ./.cache/data:/data
       - ./__tests__/rstudio-connect.test.gcfg:/etc/rstudio-connect/rstudio-connect.gcfg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,11 @@
 services:
-  db:
-    image: postgres:12
-    volumes:
-      - ./.cache/pgdata:/var/lib/postgresql/data
-    environment:
-      POSTGRES_PASSWORD: notasecret
   connect:
     privileged: true
-    depends_on:
-      - db
     image: rstudio/rstudio-connect:ubuntu2204-2024.05.0
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3939/"]
+      start_period: 30s
+      start_interval: 1s
     volumes:
       - ./.cache/data:/data
       - ./__tests__/rstudio-connect.test.gcfg:/etc/rstudio-connect/rstudio-connect.gcfg


### PR DESCRIPTION
* Updates outdated actions.
* Upgrades Connect to the most recent release.
* Uses `docker compose` not `docker-compose`.
* Wait for Connect to be healthy before `up` completes, which avoids a test-run race condition.
* Remove PostgreSQL from the compose configuration in favor of SQLite, which made the test requirements lighter. Also avoids a Connect-DB race during startup.
* Updates the automatic test API key.
* Updates configuration to be more similar with the default included in the Docker image, but with "easy peasy testing".

Needed ahead of https://github.com/rstudio/rsconnect-ts/issues/29
