### PR TITLE
Use the v1 vanity API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ clean:
 
 .PHONY: distclean
 distclean: clean
-	rm -rf __tests__/data/*
+	rm -rf .cache/data
 
 .PHONY: up
 up: .require-license

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,6 @@ module.exports = {
   clearMocks: true,
   collectCoverage: true,
   coverageDirectory: 'coverage',
-  modulePathIgnorePatterns: ["./__tests__/data/"],
   preset: 'ts-jest',
   testEnvironment: 'node'
 }

--- a/src/APIClient.ts
+++ b/src/APIClient.ts
@@ -111,10 +111,10 @@ export class APIClient {
       .then((resp: AxiosResponse) => keysToCamel(resp.data))
   }
 
-  public async updateAppVanityURL (appID: number, vanityURL: string): Promise<VanityRecordResponse> {
-    return await this.client.post(
-            `applications/${appID}/vanities`,
-            { app_id: appID, path_prefix: vanityURL }
+  public async setContentVanityURL (contentGUID: string, vanityURL: string): Promise<VanityRecordResponse> {
+    return await this.client.put(
+            `v1/content/${contentGUID}/vanity`,
+            { path: vanityURL }
     ).then((resp: AxiosResponse) => keysToCamel(resp.data))
   }
 

--- a/src/Deployer.ts
+++ b/src/Deployer.ts
@@ -156,7 +156,7 @@ export class Deployer {
         `path=${JSON.stringify(resolvedAppPath)}`
       ].join(' '))
 
-      await this.client.updateAppVanityURL(app.id, resolvedAppPath)
+      await this.client.setContentVanityURL(app.guid, resolvedAppPath)
         .catch((err: any) => {
           debugLog(() => [
             'Deployer: failed to update vanity URL for',

--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -102,9 +102,7 @@ export interface ListApplicationsResponse {
 }
 
 export interface VanityRecordResponse {
-  id?: number
-  appId: number
-  appGuid: string
-  pathPrefix: string
-  createdTime?: Date
+  contentGuid: string
+  path: string
+  createdTime: Date
 }


### PR DESCRIPTION
Builds upon #30 (for passing CI)

The v1 vanity API is available in all supported Connect versions. No need to fall-back to the unversioned API path.

Fixes #29