### PR TITLE
distclean: .cache/data not __test__/data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ clean:
 
 .PHONY: distclean
 distclean: clean
-	rm -rf .cache/data
+	rm -rf .cache/
 
 .PHONY: up
 up: .require-license

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@ module.exports = {
   clearMocks: true,
   collectCoverage: true,
   coverageDirectory: 'coverage',
+  modulePathIgnorePatterns: ["./.cache/"],
   preset: 'ts-jest',
   testEnvironment: 'node'
 }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,4 +1,4 @@
 {
-  "exclude": ["node_modules", "__tests__/data/**/*", "lib/**/*"],
+  "exclude": ["node_modules", ".cache/**/*", "lib/**/*"],
   "extends": "./tsconfig.json"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,6 @@
     "outDir": "./lib",
     "resolveJsonModule": true
   },
-  "exclude": ["node_modules", "__tests__/**/*.spec.ts", "__tests__/data/**/*", "lib/**/*"],
+  "exclude": ["node_modules", "__tests__/**/*.spec.ts", ".cache/**/*", "lib/**/*"],
   "extends": "@tsconfig/node16/tsconfig.json"
 }


### PR DESCRIPTION
It looks like __test__/data was previously used as the Connect data directory, but that has since moved to .cache/data. Update configuration to reflect that location.