### PR TITLE
connect: use the public /v1/tasks/{id} endpoint

### DIFF
--- a/__tests__/main.spec.ts
+++ b/__tests__/main.spec.ts
@@ -74,8 +74,9 @@ describe('rsconnect', () => {
           .then(async (poller: rsconnect.ClientTaskPoller) => {
             for await (const result of poller.poll()) {
               expect(result).not.toBeNull()
-              expect(result.status).not.toBeNull()
-              expect(result.status.length).toBeGreaterThan(-1)
+              expect(result.output).not.toBeNull()
+              expect(result.output.length).toBeGreaterThan(-1)
+              // console.log(result.output)
             }
           })
           .catch((err: any) => {
@@ -97,8 +98,9 @@ describe('rsconnect', () => {
           .then(async (poller: rsconnect.ClientTaskPoller) => {
             for await (const result of poller.poll()) {
               expect(result).not.toBeNull()
-              expect(result.status).not.toBeNull()
-              expect(result.status.length).toBeGreaterThan(-1)
+              expect(result.output).not.toBeNull()
+              expect(result.output.length).toBeGreaterThan(-1)
+              // console.log(result.output)
             }
           })
           .catch((err: any) => {

--- a/src/APIClient.ts
+++ b/src/APIClient.ts
@@ -8,7 +8,9 @@ import { debugLog, debugEnabled } from './debugLog'
 import {
   Application,
   AppEnvironmentResponse,
-  ClientTaskResponse,
+  ClientTaskV0Response,
+  ClientTaskV1Params,
+  ClientTaskV1Response,
   ExtendedBundleResponse,
   ListApplicationsParams,
   ListApplicationsResponse,
@@ -118,7 +120,7 @@ export class APIClient {
     ).then((resp: AxiosResponse) => keysToCamel(resp.data))
   }
 
-  public async deployApp (appID: number, bundleID: number): Promise<ClientTaskResponse> {
+  public async deployApp (appID: number, bundleID: number): Promise<ClientTaskV0Response> {
     return await this.client.post(
             `applications/${appID}/deploy`,
             { bundle: bundleID }
@@ -155,13 +157,13 @@ export class APIClient {
     )
   }
 
-  public async getTask (taskId: string, status?: number): Promise<ClientTaskResponse> {
-    return await this.client.get(
-            `tasks/${taskId}`,
-            status !== null && status !== undefined
-              ? { params: { first_status: status } }
-              : undefined
-    ).then((resp: AxiosResponse) => keysToCamel(resp.data))
+  public async getTask (taskId: string, first?: number, wait?: number): Promise<ClientTaskV1Response> {
+    const params: ClientTaskV1Params = {
+      first: (first !== null && first !== undefined) ? first : undefined,
+      wait: (wait !== null && wait !== undefined) ? wait : undefined
+    }
+    return await this.client.get(`v1/tasks/${taskId}`, { params })
+      .then((resp: AxiosResponse) => keysToCamel(resp.data))
   }
 
   public async getBundle (bundleId: number): Promise<ExtendedBundleResponse> {

--- a/src/Deployer.ts
+++ b/src/Deployer.ts
@@ -5,7 +5,7 @@ import { debugLog } from './debugLog'
 import { APIClient } from './APIClient'
 import { Bundle } from './Bundle'
 import { Bundler } from './Bundler'
-import { Application, ClientTaskResponse, ListApplicationsResponse } from './api-types'
+import { Application, ClientTaskV0Response, ListApplicationsResponse } from './api-types'
 import { ApplicationPather } from './ApplicationPather'
 
 export interface DeployManifestParams {
@@ -208,7 +208,7 @@ export class Deployer {
     ].join(' '))
 
     return await this.client.deployApp(app.id, uploadedBundle.id)
-      .then((ct: ClientTaskResponse) => {
+      .then((ct: ClientTaskV0Response) => {
         return {
           appGuid: app.guid,
           appId: app.id,

--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -54,7 +54,7 @@ export interface Application {
   git?: AppGitRecord
 }
 
-export interface ClientTaskResponse {
+export interface ClientTaskV0Response {
   id: string
   userId: number
   status: string[]
@@ -63,6 +63,21 @@ export interface ClientTaskResponse {
   code: number
   error: string
   lastStatus: number
+}
+
+export interface ClientTaskV1Params {
+  first?: number
+  wait?: number
+}
+
+export interface ClientTaskV1Response {
+  id: string
+  output: string[]
+  result?: ClientTaskResult
+  finished: boolean
+  code: number
+  error: string
+  last: number
 }
 
 export interface ClientTaskResult {


### PR DESCRIPTION
* deployApp() continues to return a v0 task
* getTask() accepts first and wait arguments and returns a v1 task
* ClientTaskPoller uses long-polling rather than sleeping; returns a result with "output" rather than "status"

fixes #38