### PR TITLE
docker compose logs not docker-compose logs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - run: make
       - run: git diff --exit-code
       - if: failure()
-        run: docker-compose logs
+        run: docker compose logs
       - run: make down
       - run: printf '//registry.npmjs.org/:_authToken=%s\n' "${NPM_AUTH_TOKEN}" | tee .npmrc
         env:


### PR DESCRIPTION
Sadly, only runs on failure, but recent 0.8.0 PR saw this problem.