### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rstudio/rsconnect-ts",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rstudio/rsconnect-ts",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "^4.17.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstudio/rsconnect-ts",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "TypeScript client library for the Posit Connect API",
   "author": "RStudio Developers <support+rsconnect-ts@rstudio.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Bump `package.json` version from 0.8.0 → 0.9.0 in preparation for the next release.

Highlights since v0.8.0:
- Refactor to use Connect v1 APIs (#46)
- Read runtime version from `package.json` (#48)
- Dependency bumps incl. Node LTS update (#49) and the recent Jest 30 / TypeScript 6 / cookie-stack work (#51)

## Release steps after merge
1. Pull `main`
2. Tag the merge commit `v0.9.0` and push the tag
3. GitHub Actions runs tests then `npm publish`

## Test plan
- [x] CI green