### PR TITLE
ci: switch npm publish to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,9 +46,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
-      - run: npm install -g npm@latest
       - run: npm install
       - run: npm run build
       - if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,17 +39,18 @@ jobs:
   publish:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 22.x
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install -g npm@latest
       - run: npm install
       - run: npm run build
-      - run: printf '//registry.npmjs.org/:_authToken=%s\n' "${NPM_AUTH_TOKEN}" | tee .npmrc
-        env:
-          NPM_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
-      - run: npm info
       - if: startsWith(github.ref, 'refs/tags')
         run: npm publish
       - if: startsWith(github.ref, 'refs/heads')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,5 +52,5 @@ jobs:
       - run: npm run build
       - if: startsWith(github.ref, 'refs/tags')
         run: npm publish
-      - if: startsWith(github.ref, 'refs/heads')
+      - if: github.event_name == 'pull_request'
         run: npm publish --dry-run


### PR DESCRIPTION
## Summary
Switch the `publish` job to use [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) via GitHub Actions OIDC, matching the trusted publisher already configured on the npm side.

Changes to the publish job:
- Grant `id-token: write` so the workflow can mint an OIDC token
- Configure `actions/setup-node` with `registry-url: https://registry.npmjs.org`
- `npm install -g npm@latest` to satisfy the npm CLI ≥ 11.5.1 requirement for OIDC
- Drop the manual `NODE_AUTH_TOKEN` / `.npmrc` setup — the npm CLI auths via OIDC against the trusted publisher

Provenance attestations are generated automatically when publishing this way, so no `--provenance` flag is needed. The `NODE_AUTH_TOKEN` repo secret can be removed once this lands.

## Test plan
- [ ] CI green; `publish` job runs `npm publish --dry-run` on the merge to `main` and exits 0
- [ ] After merge: tag `v0.9.0` and confirm a real publish succeeds via OIDC